### PR TITLE
Add rstudio

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rocker/r-ver:4.3.2
+FROM rocker/rstudio:4.3.2
 # To run rstudio, change above to FROM rocker/rstudio:4.3.2
 
 ## Set a default user. Available via runtime flag `--user rserve`

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Type 'q()' to quit R.
 
 >
 ```
+&nbsp;&nbsp;&nbsp;&nbsp; Alternatively, to start RStudio run 
+```
+docker run -d -p 8787:8787 -e PASSWORD=password -v $(pwd):/home/rstudio/Documents rdev:dev
+```
+&nbsp;&nbsp;&nbsp;&nbsp; This will start an RStudio session. If the browser does not open automatically, navigate to `http://localhost:8787/`. 
+
 3. Now we're ready to load our package. The function `loadDevPackages` will both load the package of interest and install VEuPath dependencies if they exist. If we want to work on veupathUtils, for example, run
 ```
 loadDevPackages('veupathUtils')


### PR DESCRIPTION
This PR adds support for RStudio. See readme changes for how to run!

The only funny thing I noticed was that the `.dev` folder isn't visible to RStudio. I'm not sure why. However, it's truly not crucial so I'm going to leave that issue for figuring out later. 