### PR TITLE
Update start-shell to make it compatible with new base image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ build:
 
 .PHONY: start-shell
 start-shell:
-	@docker run -p 8081:8888 --rm -v $(pwd):/home/dev -it $(local_name):$(tag) $(run_cmd)
+	@docker run -p 8081:8888 --rm -v $(pwd):/home/dev -it $(local_name):$(tag) R
 
 .PHONY: stop
 stop:


### PR DESCRIPTION
When I had added compatibility with R Studio, the `make start-shell` command broke. A simple update seems to have fixed the problem.