### PR TITLE
Update instructions for RStudio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@
 .vscode/
 .devcontainer/
 
+# RStudio
+.config
+.local
+
 # Repositories
 Rserve/
 veupathUtils/

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN R -e "install.packages('remotes')"
 RUN R -e "install.packages('Rcpp')"
 RUN R -e "install.packages('readr')"
 RUN R -e "install.packages('digest')"
+RUN R -e "install.packages('Hmisc')"
 
 ### Bioconductor
 RUN R -e "install.packages('BiocManager')"

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Type 'q()' to quit R.
 ```
 &nbsp;&nbsp;&nbsp;&nbsp; Alternatively, to start RStudio run 
 ```
-docker run -d -p 8787:8787 -e PASSWORD=password -v $(pwd):/home/rstudio/Documents rdev:dev
+docker run -d -p 8787:8787 -e PASSWORD=password -v $PWD:/home/rstudio rdev:dev
 ```
-&nbsp;&nbsp;&nbsp;&nbsp; This will start an RStudio session. If the browser does not open automatically, navigate to `http://localhost:8787/`. 
+&nbsp;&nbsp;&nbsp;&nbsp; This will start an RStudio session. If the browser does not open automatically, navigate to `http://localhost:8787/`. If you already have RStudio running locally on your machine, you can map a different port, e.g. `-p 8888:8787` and access using `http://localhost:8888/`.
 
 3. Now we're ready to load our package. The function `loadDevPackages` will both load the package of interest and install VEuPath dependencies if they exist. If we want to work on veupathUtils, for example, run
 ```


### PR DESCRIPTION
Mapping the current R-local-dev directory to `/home/rstudio/Documents` meant that `source('.dev/setup.R')` was not working (see last line of Dockerfile). Hopefully this will work OK!

(Branched this off the Hmisc branch. Will figure out a merging strategy next week.)